### PR TITLE
Change getActiveAccount to be getAllAccounts

### DIFF
--- a/1-Authentication/1-sign-in-react/SPA/src/index.js
+++ b/1-Authentication/1-sign-in-react/SPA/src/index.js
@@ -16,7 +16,7 @@ const msalInstance = new PublicClientApplication(msalConfig);
 // Default to using the first account if no account is active on page load
 if (!msalInstance.getActiveAccount() && msalInstance.getAllAccounts().length > 0) {
     // Account selection logic is app dependent. Adjust as needed for different use cases.
-    msalInstance.setActiveAccount(msalInstance.getActiveAccount()[0]);
+    msalInstance.setActiveAccount(msalInstance.getAllAccounts()[0]);
 }
 
 // Listen for sign-in event and set active account


### PR DESCRIPTION
## Purpose
When using the sample, I noticed a small error with the original sample. In the example there is a section that says you should set the active account by doing the following:

`getActiveAccount()[0]`

This wouldn't make sense since why would you be setting active account by getting the first active account if `getActiveAccount()` is false? I believe this is erroneous and should be `getAllAccounts()` based on the logic.

## Does this introduce a breaking change?
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```