### PR TITLE
[#113] Updates supported dotnet framework from 7.x to 8.x

### DIFF
--- a/2-Authorization/2-call-api-angular/API/ToDoListAPI/ToDoListAPI.csproj
+++ b/2-Authorization/2-call-api-angular/API/ToDoListAPI/ToDoListAPI.csproj
@@ -1,22 +1,24 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <UserSecretsId>aspnet-TodoListAPI-BA938C29-8BAB-4664-A688-8FD54049C1C3</UserSecretsId>
     <WebProject_DirectoryAccessLevelKey>1</WebProject_DirectoryAccessLevelKey>
+    <NoDefaultLaunchSettingsFile>true</NoDefaultLaunchSettingsFile>
+    <StaticWebAssetProjectMode>Default</StaticWebAssetProjectMode>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.5" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="7.0.5" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="7.0.5" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="7.0.5">
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Identity.Web" Version="2.9.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="7.0.6" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="7.0.5" Condition="'$(Configuration)' == 'Debug'" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="8.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="8.0.0" Condition="'$(Configuration)' == 'Debug'" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Purpose
Updates .Net API backend part of the sample `2-Authorization/2-call-api-angular` tutorial from deprecated .Net7 to supported, latest .Net8 so that new users can play, too. This addresses my issue #113 

## Does this introduce a breaking change?

```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[x] Other... Please describe:
   Updates codebase to support latest .Net framework
```

## How to Test
* Get the code
* Run the sample `2-Authorization/2-call-api-angular/API/ToDoListAPI` with the normal `dotnet run`

* Test the code
```
dotnet run
```

## What to Check
Verify that the following are valid
* No messages about .Net 7 framework not found and instead a message like the following shows:
```
✗ dotnet run      
info: Microsoft.Hosting.Lifetime[14]
      Now listening on: https://localhost:44351
info: Microsoft.Hosting.Lifetime[0]
      Application started. Press Ctrl+C to shut down.
info: Microsoft.Hosting.Lifetime[0]
      Hosting environment: Development
info: Microsoft.Hosting.Lifetime[0]
      Content root path: /Users/bronius/projects/sandbox/ms-identity-ciam-javascript-tutorial/2-Authorization/2-call-api-angular/API/ToDoListAPI
```

## Other Information

This only updates the code sample in the one example in this repo. There may be others.