### PR TITLE
Set redirectUri on the loginRequest 

### DIFF
--- a/1-Authentication/0-sign-in-vanillajs/App/public/authRedirect.js
+++ b/1-Authentication/0-sign-in-vanillajs/App/public/authRedirect.js
@@ -81,7 +81,7 @@ function signIn() {
      * You can pass a custom request object below. This will override the initial configuration. For more information, visit:
      * https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/dev/lib/msal-browser/docs/request-response-object.md#request
      */
-
+    loginRequest.redirectUri = "/";
     myMSALObj.loginRedirect(loginRequest);
 }
 

--- a/1-Authentication/0-sign-in-vanillajs/README.md
+++ b/1-Authentication/0-sign-in-vanillajs/README.md
@@ -85,7 +85,7 @@ or download and extract the repository *.zip* file.
 ### Step 2: Install project dependencies
 
 ```console
-    cd 1-Authorization\0-sign-in-vanillajs\App
+    cd 1-Authentication\0-sign-in-vanillajs\App
     npm install
 ```
 


### PR DESCRIPTION
## Purpose
On the VanillaJS sample; I noticed that after signing in, the browser is redirected to an empty page (redirect.html) instead of the index.html page that shows the claims on the token. When that happens, one is not able to explore other parts of the sample app.

## Does this introduce a breaking change?
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone https://github.com/jadeoti/ms-identity-ciam-javascript-tutorial.git
cd ms-identity-ciam-javascript-tutorial
git checkout main
npm install
```

* Test the code
```
npm start
```

## What to Check
Verify that the following are valid
- After completing the Sign Up process, the user is redirected to the index.html page, where the token information is displayed instead of being redirected to the blank redirect.html page.